### PR TITLE
Optional db create

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ var rootCmd = &cobra.Command{
 This application is used as part of testing potential candiates at Vibrato.
 
 Please visit http://vibrato.com.au for more details`,
-	Version: "0.3.1",
+	Version: "0.3.2",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/updatedb.go
+++ b/cmd/updatedb.go
@@ -41,21 +41,26 @@ var updatedbCmd = &cobra.Command{
 	},
 }
 
+var skipCreateDbOption bool
+
 func init() {
 	rootCmd.AddCommand(updatedbCmd)
+	updatedbCmd.Flags().BoolVarP(&skipCreateDbOption, "skip-create-db", "s", false, "Use to skip the creation of the database")
 }
 
 func updateDb(cfg db.Config) error {
 
-	fmt.Println("Dropping and recreating database: " + cfg.DbName)
-	err := db.RebuildDb(cfg)
+	if !skipCreateDbOption {
+		fmt.Println("Dropping and recreating database: " + cfg.DbName)
+		err := db.RebuildDb(cfg)
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println("Dropping and recreating table: tasks")
-	err = db.CreateTable(cfg)
+	err := db.CreateTable(cfg)
 
 	if err != nil {
 		return err

--- a/db/db.go
+++ b/db/db.go
@@ -47,7 +47,7 @@ func getDbInfo(cfg Config) string {
 
 // RebuildDb drops the database and recreates it
 func RebuildDb(cfg Config) error {
-	dbinfo := fmt.Sprintf("host=%s port=%s user=%s password=%s sslmode=disable",
+	dbinfo := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable",
 		cfg.DbHost, cfg.DbPort, cfg.DbUser, cfg.DbPassword)
 
 	db, err := sql.Open("postgres", dbinfo)

--- a/doc/adr/0005-skip-create-database.md
+++ b/doc/adr/0005-skip-create-database.md
@@ -1,0 +1,19 @@
+# 5. skip create database
+
+Date: 2018-08-19
+
+## Status
+
+Accepted
+
+## Context
+
+Database upgrade script contains everything required to deploy and seed a test database. Some PaaS services like azure db have requirements that means it is difficult to have a generic way to create the database.
+
+## Decision
+
+To make it easier, we've decided to add an option to skip the database creation and allow for an external process to create the database while still creating tables and seeding it with data.
+
+## Consequences
+
+none

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -43,7 +43,7 @@ It is completely self contained, and should not require any additional dependenc
 
 update `conf.toml` with database settings (details on how to configure the application can be found in [config.md](config.md))
 
-`./TechTestApp updatedb` to create a database and seed it with test data
+`./TechTestApp updatedb` to create a database, tables, and seed it with test data. Use `-s` to skip creating the database.
 
 `./TechTestApp serve` will start serving requests
 


### PR DESCRIPTION
### Description

Added flag to `updatedb` command to allow for skipping the database create step, allowing it to be created from deployment scripts.

Fixes: https://github.com/vibrato/TechTestApp/issues/19

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added issue number to `Fixes` line above
