### PR TITLE
Fix config white space

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ var rootCmd = &cobra.Command{
 This application is used as part of testing potential candiates at Vibrato.
 
 Please visit http://vibrato.com.au for more details`,
-	Version: "0.3.3",
+	Version: "0.3.4",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/spf13/viper"
 )
 
@@ -63,13 +65,13 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
-	conf.DbUser = v.GetString("DbUser")
-	conf.DbPassword = v.GetString("DbPassword")
-	conf.DbName = v.GetString("DbName")
-	conf.DbHost = v.GetString("DbHost")
-	conf.DbPort = v.GetString("DbPort")
-	conf.ListenHost = v.GetString("ListenHost")
-	conf.ListenPort = v.GetString("ListenPort")
+	conf.DbUser = strings.TrimSpace(v.GetString("DbUser"))
+	conf.DbPassword = strings.TrimSpace(v.GetString("DbPassword"))
+	conf.DbName = strings.TrimSpace(v.GetString("DbName"))
+	conf.DbHost = strings.TrimSpace(v.GetString("DbHost"))
+	conf.DbPort = strings.TrimSpace(v.GetString("DbPort"))
+	conf.ListenHost = strings.TrimSpace(v.GetString("ListenHost"))
+	conf.ListenPort = strings.TrimSpace(v.GetString("ListenPort"))
 
 	return conf, nil
 }


### PR DESCRIPTION
### Description

Added trimming of whitespace to config variables, so this will now allow for sloppiness or buggy tools that adds in white space.

Fixes: https://github.com/vibrato/TechTestApp/issues/23

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added issue number to `Fixes` line above
