### PR TITLE
Change docker entrypoint to simply the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=build /tmp/swagger/dist ./assets/swagger
 COPY --from=build /swagger.json ./assets/swagger/swagger.json
 COPY --from=build /TechTestApp TechTestApp
 
-ENTRYPOINT [ "./TechTestApp",  "serve" ]
+ENTRYPOINT [ "./TechTestApp" ]


### PR DESCRIPTION
Having the ENTRYPOINT contain "serve" makes it more difficult than it
should be to do things like run the migrations or other commands that
are spawned from the application.

This is particularly obvious when you want to do something like
docker-compose where you want to specify the COMMAND like "updatedb" or
"serve" on top of the entrypoint.