### PR TITLE
Fix failing docker builds by building go-swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM golang:alpine AS build
 
-RUN apk add --no-cache curl git gcc linux-headers musl-dev
+RUN apk add --no-cache curl git alpine-sdk
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
-ARG GO_SWAGGER_VERSION=0.18.0
 ARG SWAGGER_UI_VERSION=3.20.9
 
-RUN curl -sfL -o /usr/local/bin/swagger https://github.com/go-swagger/go-swagger/releases/download/v$GO_SWAGGER_VERSION/swagger_linux_amd64 \
-    && chmod +x /usr/local/bin/swagger \
+RUN go get -d -v github.com/go-swagger/go-swagger \
+    && go install github.com/go-swagger/go-swagger/cmd/swagger \
     && curl -sfL https://github.com/swagger-api/swagger-ui/archive/v$SWAGGER_UI_VERSION.tar.gz | tar xz -C /tmp/ \
     && mv /tmp/swagger-ui-$SWAGGER_UI_VERSION /tmp/swagger \
     && sed -i 's#"https://petstore\.swagger\.io/v2/swagger\.json"#"./swagger.json"#g' /tmp/swagger/dist/index.html


### PR DESCRIPTION
It appears that the downloaded go swagger is built with golang 1.10 and
installing it and running it against the golang 1.11 base causes a bunch
of problems.

We can download and build go-swagger ourselves, but unless we put it
into dep we can't pin a specific version and more and we're just running
from master.

That's a problem, but less of a problem than simply not building.